### PR TITLE
test CSV output

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 			}
 			tw.AppendFooter(table.Row{"Total", ac.FormatMoney(totalAmount), ac.FormatMoney(totalSecondAmount), ac.FormatMoney(totalDelta)})
 			fmt.Printf("\n")
-			fmt.Printf(tw.Render())
+			fmt.Printf(tw.RenderCSV())
 			fmt.Printf("\n")
 			return nil
 		},


### PR DESCRIPTION
Fixes #3 

A quick test of enabling CSV output directly (no flag yet). Pretty easy to switch from table to CSV, but I'm having trouble removing the `,` separator for thousands which means that it's escaping the comma during output (`\,`).

I attempted the following but they didn't seem to have any impact:

```
ac := accounting.Accounting{Symbol: "$", Precision: 2, Thousand: ""}
```

```
ac.SetThousandSeparator("")
```

According to https://github.com/leekchan/accounting/issues/8#issuecomment-379696585 it should work, but maybe I'm missing something.

Alternatively the separator could be something besides `,` (tab?) instead which would remove the issue.

### Example output

```
❯ go build && ./aws-cct

Service,2020-09-01,2020-10-01 (projection),Delta
AWS CodePipeline,$29.12,$30.38,$1.26
Amazon Elastic Container Service for Kubernetes,$261.26,$206.76,-$54.50
Amazon Kinesis Firehose,$0.06,$0.00,-$0.06
EC2 - Other,"$6\,146.70","$5\,951.19",-$195.51
...
Total,"$12\,345.67","$89\,012.34","-$56\,789.01"
```