### PR TITLE
Remove unneeded flag due to brew warning

### DIFF
--- a/aws-cct.rb
+++ b/aws-cct.rb
@@ -6,7 +6,6 @@ class AwsCct < Formula
   desc "AWS Cost Comparison Tool"
   homepage "https://github.com/rocketmiles/aws-cct"
   version "1.4.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Context:
During a brew update I received this warning
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the rocketmiles/aws-cct tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/rocketmiles/homebrew-aws-cct/aws-cct.rb:9
```